### PR TITLE
hide methods only used in AvroValues

### DIFF
--- a/modules/core/src/main/scala/com/collibra/plugin/RuleParser.scala
+++ b/modules/core/src/main/scala/com/collibra/plugin/RuleParser.scala
@@ -1,6 +1,6 @@
 package com.collibra.plugin
 
-import au.com.dius.pact.core.model.matchingrules
+import au.com.dius.pact.core.model.matchingrules.MatchingRule
 import au.com.dius.pact.core.model.matchingrules.expressions.MatchingRuleDefinition
 import com.collibra.plugin.avro.implicits.AvroSupportImplicits.{fromPactEither, fromPactResult}
 import com.collibra.plugin.avro.utils.{PluginError, PluginErrorMessage, PluginErrorMessages}
@@ -8,8 +8,10 @@ import com.google.protobuf.struct.Value
 
 import scala.jdk.CollectionConverters._
 
+case class FieldRule(value: String, rules: Seq[MatchingRule])
+
 object RuleParser {
-  def parseRules(inValue: Value): Either[PluginError[_], (String, Seq[matchingrules.MatchingRule])] = {
+  def parseRules(inValue: Value): Either[PluginError[_], FieldRule] = {
     fromPactResult(MatchingRuleDefinition.parseMatchingRuleDefinition(inValue.getStringValue)) match {
       case Right(ok) =>
         ok.getRules.asScala.toSeq
@@ -20,7 +22,7 @@ object RuleParser {
           }
           .partitionMap(identity) match {
           case (errors, _) if errors.nonEmpty => Left(PluginErrorMessages(errors))
-          case (_, rules)                     => Right((ok.getValue, rules))
+          case (_, rules)                     => Right(FieldRule(ok.getValue, rules))
         }
       case Left(err) =>
         Left(PluginErrorMessage(s"'${inValue.getStringValue}' is not a valid matching rule definition - $err"))

--- a/modules/core/src/main/scala/com/collibra/plugin/avro/AvroRecord.scala
+++ b/modules/core/src/main/scala/com/collibra/plugin/avro/AvroRecord.scala
@@ -7,7 +7,7 @@ import com.collibra.plugin.avro.utils.StringUtils._
 import com.collibra.plugin.avro.utils._
 import com.google.protobuf.ByteString
 import com.google.protobuf.struct.Value
-import com.google.protobuf.struct.Value.Kind
+import com.google.protobuf.struct.Value.Kind._
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.avro.Schema
 import org.apache.avro.Schema.Type._
@@ -32,398 +32,398 @@ case class PactFieldPath(segments: List[String]) {
 
   def startsWith(other: PactFieldPath): Boolean = segments.startsWith(other.segments)
 
-  def toJsonPath = segments.mkString(".")
-
-  def insertAt(i: Int, value: String): PactFieldPath = PactFieldPath(segments.take(i) ++ List(value) ++ segments.drop(i))
+  def toJsonPath: String = segments.mkString(".")
 
   def size: Int = segments.size
 }
 
-sealed trait AvroValue {
+object Avro {
+  sealed trait AvroValue {
 
-  type AvroValueType
-  def path: PactFieldPath
-  def name: AvroFieldName
-  def value: AvroValueType
-  def rules: Seq[MatchingRule]
+    type AvroValueType
 
-  def addRules(matchingRules: MatchingRuleCategory): Unit = matchingRules.addRules(path.toJsonPath, rules.asJava)
-}
+    def path: PactFieldPath
 
-object AvroValue extends StrictLogging {
+    def name: AvroFieldName
 
-  def apply(
-    rootPath: PactFieldPath,
-    fieldName: AvroFieldName,
-    schema: Schema,
-    inValue: Value,
-    appendPath: Boolean = true
-  ): Either[Seq[PluginError[_]], AvroValue] = {
-    val path = if (appendPath) rootPath :+ fieldName else rootPath
-    logger.debug(s">>> buildFieldValue($path, $fieldName, $inValue)")
-    val schemaType = schema.getType match {
-      case ARRAY => schema.getElementType.getType
-      case MAP   => schema.getValueType.getType
-      case _     => schema.getType
-    }
-    inValue.kind match {
-      case Kind.Empty        => Right(AvroNull(path, fieldName))
-      case Kind.NullValue(_) => Right(AvroNull(path, fieldName))
-      case Kind.StringValue(_) =>
-        parseRules(inValue)
-          .flatMap { case (fieldValue, rules) =>
-            AvroValue(path, fieldName, schemaType, fieldValue, rules)
-          }
-          .left
-          .map(e => Seq(e))
-      case Kind.ListValue(listValue) =>
-        (listValue.values.map(parseRules).partitionMap(identity) match {
-          case (errors, _) if errors.nonEmpty => Left(errors)
-          case (_, result)                    => Right(result)
-        }).map { result =>
-          result.foldLeft((Seq.empty[String], Seq.empty[MatchingRule])) { (acc, values) =>
-            (acc._1 :+ values._1) -> (acc._2 ++ values._2)
-          }
-        }.map { case (fieldValues, rules) =>
-          AvroValue(path, fieldName, schemaType, fieldValues, rules)
-        } match {
-          case Right(Right(value)) => Right(value)
-          case Right(Left(error))  => Left(Seq(error))
-          case Left(errors)        => Left(errors)
-        }
-      case Kind.NumberValue(_) => Left(Seq(PluginErrorMessage(s"Number kind value for field is not supported")))
-      case Kind.BoolValue(_)   => Left(Seq(PluginErrorMessage(s"Bool kind value for field is not supported")))
-      case Kind.StructValue(_) =>
-        if (schemaType == RECORD) {
-          AvroRecord(path, fieldName, schema.getElementType, inValue.getStructValue.fields)
-        } else {
-          Left(Seq(PluginErrorMessage(s"Struct kind value for field is not supported")))
-        }
-    }
-  }
-  def apply(
-    path: PactFieldPath,
-    fieldName: AvroFieldName,
-    schemaType: Schema.Type,
-    fieldValue: Object,
-    rules: Seq[MatchingRule]
-  ): Either[PluginError[_], AvroValue] = {
-    fieldValue match {
-      case value: String => fromString(path, fieldName, schemaType, value, rules)
-      case _ =>
-        (schemaType match {
-          case BOOLEAN => Try(AvroBoolean(path, fieldName, fieldValue.asInstanceOf[Boolean], rules)).toEither
-          case BYTES =>
-            Right(
-              AvroString(path, fieldName, new String(fieldValue.asInstanceOf[Array[Byte]], StandardCharsets.UTF_8), rules)
-            ) // TODO: Use bytes, Using String values for now
-          case DOUBLE => Try(AvroDouble(path, fieldName, fieldValue.asInstanceOf[Double], rules)).toEither
-          case ENUM   => Try(AvroEnum(path, fieldName, fieldValue.asInstanceOf[String])).toEither
-          case FIXED =>
-            Right(
-              AvroString(path, fieldName, new String(fieldValue.asInstanceOf[Array[Byte]], StandardCharsets.UTF_8), rules)
-            ) // TODO: Use bytes, Using String values for now
-          case FLOAT  => Try(AvroFloat(path, fieldName, fieldValue.asInstanceOf[Float], rules)).toEither
-          case INT    => Try(AvroInt(path, fieldName, fieldValue.asInstanceOf[Int], rules)).toEither
-          case LONG   => Try(AvroLong(path, fieldName, fieldValue.asInstanceOf[Long], rules)).toEither
-          case NULL   => Right(AvroNull(path, fieldName))
-          case STRING => Try(AvroString(path, fieldName, fieldValue.asInstanceOf[String], rules)).toEither
-          case ARRAY  => Left(new UnsupportedOperationException(s"'ARRAY' not support as AvroValue: '$fieldValue'"))
-          case MAP    => Left(new UnsupportedOperationException(s"'MAP' not support as AvroValue: '$fieldValue'"))
-          case RECORD => Left(new UnsupportedOperationException(s"'RECORD' not support as AvroValue: '$fieldValue'"))
-          case UNION  => Left(new UnsupportedOperationException(s"'UNION' not support as AvroValue: '$fieldValue'"))
-          case t      => Left(new UnsupportedOperationException(s"Unknown type '$t' not support as AvroValue: '$fieldValue'"))
-        }).left.map(e => PluginErrorException(e))
-    }
+    def value: AvroValueType
+
+    def rules: Seq[MatchingRule]
+
+    protected[Avro] def addRules(matchingRules: MatchingRuleCategory): Unit = matchingRules.addRules(path.toJsonPath, rules.asJava)
   }
 
-  private def fromString(
-    path: PactFieldPath,
-    fieldName: AvroFieldName,
-    schemaType: Schema.Type,
-    fieldValue: String,
-    rules: Seq[MatchingRule]
-  ): Either[PluginError[_], AvroValue] = {
-    (schemaType match {
-      case BOOLEAN => Right(AvroBoolean(path, fieldName, fieldValue.toLowerCase == "true", rules))
-      case BYTES   => Right(AvroString(path, fieldName, fieldValue, rules)) // TODO: Use bytes, Using String values for now
-      case DOUBLE  => Try(fieldValue.toDouble).map(v => AvroDouble(path, fieldName, v, rules)).toEither
-      case ENUM    => Right(AvroEnum(path, fieldName, fieldValue, rules))
-      case FIXED   => Right(AvroString(path, fieldName, fieldValue, rules)) // TODO: Use bytes, Using String values for now
-      case FLOAT   => Try(fieldValue.toFloat).map(v => AvroFloat(path, fieldName, v, rules)).toEither
-      case INT     => Try(fieldValue.toInt).map(v => AvroInt(path, fieldName, v, rules)).toEither
-      case LONG    => Try(fieldValue.toLong).map(v => AvroLong(path, fieldName, v, rules)).toEither
-      case NULL    => Right(AvroNull(path, fieldName))
-      case STRING  => Right(AvroString(path, fieldName, fieldValue, rules))
-      case ARRAY   => Left(new UnsupportedOperationException(s"'ARRAY' not support as AvroValue: '$fieldValue'"))
-      case MAP     => Left(new UnsupportedOperationException(s"'MAP' not support as AvroValue: '$fieldValue'"))
-      case RECORD  => Left(new UnsupportedOperationException(s"'RECORD' not support as AvroValue: '$fieldValue'"))
-      case UNION   => Left(new UnsupportedOperationException(s"'UNION' not support as AvroValue: '$fieldValue'"))
-      case t       => Left(new UnsupportedOperationException(s"Unknown type '$t' not support as AvroValue: '$fieldValue'"))
-    }).left.map(e => PluginErrorException(e))
-  }
-}
+  object AvroValue extends StrictLogging {
 
-case class AvroNull(override val path: PactFieldPath, override val name: AvroFieldName, override val value: Unit = (), rules: Seq[MatchingRule] = Seq.empty)
-    extends AvroValue {
-  override type AvroValueType = Unit
-}
-case class AvroString(override val path: PactFieldPath, override val name: AvroFieldName, override val value: String, rules: Seq[MatchingRule] = Seq.empty)
-    extends AvroValue {
-  override type AvroValueType = String
-}
-
-case class AvroEnum(override val path: PactFieldPath, override val name: AvroFieldName, override val value: String, rules: Seq[MatchingRule] = Seq.empty)
-    extends AvroValue {
-  override type AvroValueType = String
-}
-case class AvroDouble(override val path: PactFieldPath, override val name: AvroFieldName, value: Double, rules: Seq[MatchingRule] = Seq.empty)
-    extends AvroValue {
-  override type AvroValueType = Double
-}
-case class AvroFloat(override val path: PactFieldPath, override val name: AvroFieldName, value: Float, rules: Seq[MatchingRule] = Seq.empty) extends AvroValue {
-  override type AvroValueType = Float
-}
-case class AvroInt(override val path: PactFieldPath, override val name: AvroFieldName, value: Int, rules: Seq[MatchingRule] = Seq.empty) extends AvroValue {
-  override type AvroValueType = Int
-}
-case class AvroLong(override val path: PactFieldPath, override val name: AvroFieldName, value: Long, rules: Seq[MatchingRule] = Seq.empty) extends AvroValue {
-  override type AvroValueType = Long
-}
-case class AvroBoolean(override val path: PactFieldPath, override val name: AvroFieldName, value: Boolean, rules: Seq[MatchingRule] = Seq.empty)
-    extends AvroValue {
-  override type AvroValueType = Boolean
-}
-case class AvroArray(
-  override val path: PactFieldPath,
-  override val name: AvroFieldName,
-  value: List[AvroValue] = List.empty,
-  rules: Seq[MatchingRule] = Seq.empty
-) extends AvroValue {
-  override type AvroValueType = List[AvroValue]
-  def toRecordValue: util.List[Any] = value.map {
-    case a: AvroArray  => a.toRecordValue
-    case m: AvroMap    => m.toRecordValue
-    case r: AvroRecord => r
-    case v             => v.value
-  }.asJava
-
-  override def addRules(matchingRules: MatchingRuleCategory): Unit =
-    value.foreach(_.addRules(matchingRules))
-}
-
-object AvroArray {
-  def apply(rootPath: PactFieldPath, schemaField: Schema.Field, inValue: Value): Either[Seq[PluginError[_]], AvroArray] = {
-    val fieldName = AvroFieldName(schemaField.name())
-    inValue.kind match {
-      case Kind.Empty        => Right(AvroArray(rootPath, fieldName))
-      case Kind.NullValue(_) => Right(AvroArray(rootPath, fieldName))
-      case Kind.ListValue(listValue) =>
-        val arrayBasePath = rootPath :+ fieldName
-        listValue.values.zipWithIndex
-          .map { case (singleValue, index) =>
-            schemaField.schema().getElementType.getType match {
-              case RECORD => AvroValue(arrayBasePath :+ index, fieldName, schemaField.schema(), singleValue, appendPath = false)
-              case _ =>
-                AvroValue(rootPath, fieldName, schemaField.schema(), singleValue).map {
-                  case v: AvroNull    => v.copy(path = v.path :+ index)
-                  case v: AvroString  => v.copy(path = v.path :+ index)
-                  case v: AvroEnum    => v.copy(path = v.path :+ index)
-                  case v: AvroDouble  => v.copy(path = v.path :+ index)
-                  case v: AvroFloat   => v.copy(path = v.path :+ index)
-                  case v: AvroInt     => v.copy(path = v.path :+ index)
-                  case v: AvroLong    => v.copy(path = v.path :+ index)
-                  case v: AvroBoolean => v.copy(path = v.path :+ index)
-                  case v: AvroArray   => v.copy(path = v.path :+ index)
-                  case v: AvroMap     => v.copy(path = v.path :+ index)
-                  case v: AvroRecord  => v
-                }
+    def apply(
+      rootPath: PactFieldPath,
+      fieldName: AvroFieldName,
+      schema: Schema,
+      inValue: Value,
+      appendPath: Boolean = true
+    ): Either[Seq[PluginError[_]], AvroValue] = {
+      val path = if (appendPath) rootPath :+ fieldName else rootPath
+      logger.debug(s">>> buildFieldValue($path, $fieldName, $inValue)")
+      val schemaType = schema.getType match {
+        case ARRAY => schema.getElementType.getType
+        case MAP   => schema.getValueType.getType
+        case _     => schema.getType
+      }
+      inValue.kind match {
+        case Empty        => Right(AvroNull(path, fieldName))
+        case NullValue(_) => Right(AvroNull(path, fieldName))
+        case StringValue(_) =>
+          parseRules(inValue)
+            .flatMap { fieldRule =>
+              AvroValue(path, fieldName, schemaType, fieldRule.value, fieldRule.rules)
             }
+            .left
+            .map(e => Seq(e))
+        case ListValue(_)   => Left(Seq(PluginErrorMessage(s"List kind value for field is not supported")))
+        case NumberValue(_) => Left(Seq(PluginErrorMessage(s"Number kind value for field is not supported")))
+        case BoolValue(_)   => Left(Seq(PluginErrorMessage(s"Bool kind value for field is not supported")))
+        case StructValue(_) =>
+          if (schemaType == RECORD) {
+            AvroRecord(path, fieldName, schema.getElementType, inValue.getStructValue.fields)
+          } else {
+            Left(Seq(PluginErrorMessage(s"Struct kind value for field is not supported")))
           }
-          .partitionMap(identity) match {
-          case (errors, _) if errors.nonEmpty => Left(errors.flatten)
-          case (_, fields)                    => Right(AvroArray(arrayBasePath, fieldName, fields.toList))
-        }
-      case _ => Left(Seq(PluginErrorMessage(s"Expected list value for field '${fieldName.value}' but got '${inValue.kind}'")))
+      }
+    }
+
+    def apply(
+      path: PactFieldPath,
+      fieldName: AvroFieldName,
+      schemaType: Schema.Type,
+      fieldValue: Object,
+      rules: Seq[MatchingRule]
+    ): Either[PluginError[_], AvroValue] = {
+      fieldValue match {
+        case value: String => fromString(path, fieldName, schemaType, value, rules)
+        case _ =>
+          (schemaType match {
+            case BOOLEAN => Try(AvroBoolean(path, fieldName, fieldValue.asInstanceOf[Boolean], rules)).toEither
+            case BYTES =>
+              Right(
+                AvroString(path, fieldName, new String(fieldValue.asInstanceOf[Array[Byte]], StandardCharsets.UTF_8), rules)
+              ) // TODO: Use bytes, Using String values for now
+            case DOUBLE => Try(AvroDouble(path, fieldName, fieldValue.asInstanceOf[Double], rules)).toEither
+            case ENUM   => Try(AvroEnum(path, fieldName, fieldValue.asInstanceOf[String])).toEither
+            case FIXED =>
+              Right(
+                AvroString(path, fieldName, new String(fieldValue.asInstanceOf[Array[Byte]], StandardCharsets.UTF_8), rules)
+              ) // TODO: Use bytes, Using String values for now
+            case FLOAT  => Try(AvroFloat(path, fieldName, fieldValue.asInstanceOf[Float], rules)).toEither
+            case INT    => Try(AvroInt(path, fieldName, fieldValue.asInstanceOf[Int], rules)).toEither
+            case LONG   => Try(AvroLong(path, fieldName, fieldValue.asInstanceOf[Long], rules)).toEither
+            case NULL   => Right(AvroNull(path, fieldName))
+            case STRING => Try(AvroString(path, fieldName, fieldValue.asInstanceOf[String], rules)).toEither
+            case ARRAY  => Left(new UnsupportedOperationException(s"'ARRAY' not support as AvroValue: '$fieldValue'"))
+            case MAP    => Left(new UnsupportedOperationException(s"'MAP' not support as AvroValue: '$fieldValue'"))
+            case RECORD => Left(new UnsupportedOperationException(s"'RECORD' not support as AvroValue: '$fieldValue'"))
+            case UNION  => Left(new UnsupportedOperationException(s"'UNION' not support as AvroValue: '$fieldValue'"))
+            case t      => Left(new UnsupportedOperationException(s"Unknown type '$t' not support as AvroValue: '$fieldValue'"))
+          }).left.map(e => PluginErrorException(e))
+      }
+    }
+
+    private def fromString(
+      path: PactFieldPath,
+      fieldName: AvroFieldName,
+      schemaType: Schema.Type,
+      fieldValue: String,
+      rules: Seq[MatchingRule]
+    ): Either[PluginError[_], AvroValue] = {
+      (schemaType match {
+        case BOOLEAN => Right(AvroBoolean(path, fieldName, fieldValue.toLowerCase == "true", rules))
+        case BYTES   => Right(AvroString(path, fieldName, fieldValue, rules)) // TODO: Use bytes, Using String values for now
+        case DOUBLE  => Try(fieldValue.toDouble).map(v => AvroDouble(path, fieldName, v, rules)).toEither
+        case ENUM    => Right(AvroEnum(path, fieldName, fieldValue, rules))
+        case FIXED   => Right(AvroString(path, fieldName, fieldValue, rules)) // TODO: Use bytes, Using String values for now
+        case FLOAT   => Try(fieldValue.toFloat).map(v => AvroFloat(path, fieldName, v, rules)).toEither
+        case INT     => Try(fieldValue.toInt).map(v => AvroInt(path, fieldName, v, rules)).toEither
+        case LONG    => Try(fieldValue.toLong).map(v => AvroLong(path, fieldName, v, rules)).toEither
+        case NULL    => Right(AvroNull(path, fieldName))
+        case STRING  => Right(AvroString(path, fieldName, fieldValue, rules))
+        case ARRAY   => Left(new UnsupportedOperationException(s"'ARRAY' not support as AvroValue: '$fieldValue'"))
+        case MAP     => Left(new UnsupportedOperationException(s"'MAP' not support as AvroValue: '$fieldValue'"))
+        case RECORD  => Left(new UnsupportedOperationException(s"'RECORD' not support as AvroValue: '$fieldValue'"))
+        case UNION   => Left(new UnsupportedOperationException(s"'UNION' not support as AvroValue: '$fieldValue'"))
+        case t       => Left(new UnsupportedOperationException(s"Unknown type '$t' not support as AvroValue: '$fieldValue'"))
+      }).left.map(e => PluginErrorException(e))
     }
   }
-}
 
-case class AvroMap(
-  override val path: PactFieldPath,
-  override val name: AvroFieldName,
-  value: Map[PactFieldPath, AvroValue] = Map.empty,
-  rules: Seq[MatchingRule] = Seq.empty
-) extends AvroValue {
-  override type AvroValueType = Map[PactFieldPath, AvroValue]
-
-  def toRecordValue: util.Map[String, Any] = value.map { case (_, v) =>
-    v match {
-      case a: AvroArray  => a.name.value -> a.toRecordValue
-      case m: AvroMap    => m.name.value -> m.toRecordValue
-      case r: AvroRecord => r.name.value -> r
-      case av            => av.name.value -> av.value
-    }
-  }.asJava
-
-  override def addRules(matchingRules: MatchingRuleCategory): Unit =
-    value.foreach { case (_, field) =>
-      field.addRules(matchingRules)
-    }
-}
-
-object AvroMap {
-  def apply(rootPath: PactFieldPath, schemaField: Schema.Field, inValue: Value): Either[Seq[PluginError[_]], AvroMap] = {
-    val fieldName = AvroFieldName(schemaField.name())
-    inValue.kind match {
-      case Kind.Empty        => Right(AvroMap(rootPath, fieldName))
-      case Kind.NullValue(_) => Right(AvroMap(rootPath, fieldName))
-      case Kind.StructValue(structValue) =>
-        structValue.fields
-          .map { case (key, singleValue) =>
-            val either = AvroValue(rootPath, key.toFieldName, schemaField.schema(), singleValue)
-            either.map { v =>
-              key.toPactPath -> v
-            }
-          }
-          .partitionMap(identity) match {
-          case (errors, _) if errors.nonEmpty => Left(errors.toSeq.flatten)
-          case (_, fields)                    => Right(AvroMap(rootPath, fieldName, fields.toMap))
-        }
-      case _ => Left(Seq(PluginErrorMessage(s"Expected map value for field '${fieldName.value}' but got '${inValue.kind}'")))
-    }
-  }
-}
-
-case class AvroRecord(
-  override val path: PactFieldPath,
-  override val name: AvroFieldName,
-  override val value: Map[PactFieldPath, AvroValue],
-  rules: Seq[MatchingRule] = Seq.empty
-) extends AvroValue {
-  override type AvroValueType = Map[PactFieldPath, AvroValue]
-
-  override def addRules(matchingRules: MatchingRuleCategory): Unit =
-    value.foreach { case (_, avroValue) =>
-      avroValue.addRules(matchingRules)
-    }
-
-  def matchingRules: MatchingRuleCategory = {
-    val matchingRules: MatchingRuleCategory = new MatchingRuleCategory(MatchingRuleCategoryName)
-    addRules(matchingRules)
-    matchingRules
+  case class AvroNull(override val path: PactFieldPath, override val name: AvroFieldName, override val value: Unit = (), rules: Seq[MatchingRule] = Seq.empty)
+      extends AvroValue {
+    override type AvroValueType = Unit
   }
 
-  private def toRecordValue: util.Map[String, Any] = value.map { case (_, v) =>
-    v match {
-      case a: AvroArray  => a.name.value -> a.toRecordValue
-      case m: AvroMap    => m.name.value -> m.toRecordValue
-      case r: AvroRecord => r.name.value -> r
-      case n: AvroNull   => n.name.value -> null
-      case av            => av.name.value -> av.value
-    }
-  }.asJava
+  case class AvroString(override val path: PactFieldPath, override val name: AvroFieldName, override val value: String, rules: Seq[MatchingRule] = Seq.empty)
+      extends AvroValue {
+    override type AvroValueType = String
+  }
 
-  def toGenericRecord(schema: Schema): GenericRecord = {
-    val record: GenericRecord = new GenericData.Record(schema)
-    toRecordValue.asScala.foreach { case (key, value) =>
-      if (null != value) {
-        val field = schema.getField(key)
-        val fieldSchema = field.schema()
-        fieldSchema.getType match {
-          case ENUM =>
-            record.put(key, new GenericData.EnumSymbol(fieldSchema, value))
-          case ARRAY if fieldSchema.getElementType.getType == RECORD =>
-            val subType = fieldSchema.getElementType
-            val subRecords = value
-              .asInstanceOf[java.util.List[AvroRecord]]
-              .asScala
-              .map { item =>
-                item.toGenericRecord(subType)
+  case class AvroEnum(override val path: PactFieldPath, override val name: AvroFieldName, override val value: String, rules: Seq[MatchingRule] = Seq.empty)
+      extends AvroValue {
+    override type AvroValueType = String
+  }
+
+  case class AvroDouble(override val path: PactFieldPath, override val name: AvroFieldName, value: Double, rules: Seq[MatchingRule] = Seq.empty)
+      extends AvroValue {
+    override type AvroValueType = Double
+  }
+
+  case class AvroFloat(override val path: PactFieldPath, override val name: AvroFieldName, value: Float, rules: Seq[MatchingRule] = Seq.empty)
+      extends AvroValue {
+    override type AvroValueType = Float
+  }
+
+  case class AvroInt(override val path: PactFieldPath, override val name: AvroFieldName, value: Int, rules: Seq[MatchingRule] = Seq.empty) extends AvroValue {
+    override type AvroValueType = Int
+  }
+
+  case class AvroLong(override val path: PactFieldPath, override val name: AvroFieldName, value: Long, rules: Seq[MatchingRule] = Seq.empty) extends AvroValue {
+    override type AvroValueType = Long
+  }
+
+  case class AvroBoolean(override val path: PactFieldPath, override val name: AvroFieldName, value: Boolean, rules: Seq[MatchingRule] = Seq.empty)
+      extends AvroValue {
+    override type AvroValueType = Boolean
+  }
+
+  case class AvroArray(
+    override val path: PactFieldPath,
+    override val name: AvroFieldName,
+    value: List[AvroValue] = List.empty,
+    rules: Seq[MatchingRule] = Seq.empty
+  ) extends AvroValue {
+    override type AvroValueType = List[AvroValue]
+
+    protected[Avro] def toRecordValue: util.List[Any] = value.map {
+      case a: AvroArray  => a.toRecordValue
+      case m: AvroMap    => m.toRecordValue
+      case r: AvroRecord => r
+      case v             => v.value
+    }.asJava
+
+    protected[Avro] override def addRules(matchingRules: MatchingRuleCategory): Unit =
+      value.foreach(_.addRules(matchingRules))
+  }
+
+  object AvroArray {
+    def apply(rootPath: PactFieldPath, schemaField: Schema.Field, inValue: Value): Either[Seq[PluginError[_]], AvroArray] = {
+      val fieldName = AvroFieldName(schemaField.name())
+      inValue.kind match {
+        case Empty        => Right(AvroArray(rootPath, fieldName))
+        case NullValue(_) => Right(AvroArray(rootPath, fieldName))
+        case ListValue(listValue) =>
+          val arrayBasePath = rootPath :+ fieldName
+          listValue.values.zipWithIndex
+            .map { case (singleValue, index) =>
+              schemaField.schema().getElementType.getType match {
+                case RECORD => AvroValue(arrayBasePath :+ index, fieldName, schemaField.schema(), singleValue, appendPath = false)
+                case _ =>
+                  AvroValue(rootPath, fieldName, schemaField.schema(), singleValue).map {
+                    case v: AvroNull    => v.copy(path = v.path :+ index)
+                    case v: AvroString  => v.copy(path = v.path :+ index)
+                    case v: AvroEnum    => v.copy(path = v.path :+ index)
+                    case v: AvroDouble  => v.copy(path = v.path :+ index)
+                    case v: AvroFloat   => v.copy(path = v.path :+ index)
+                    case v: AvroInt     => v.copy(path = v.path :+ index)
+                    case v: AvroLong    => v.copy(path = v.path :+ index)
+                    case v: AvroBoolean => v.copy(path = v.path :+ index)
+                    case v: AvroArray   => v.copy(path = v.path :+ index)
+                    case v: AvroMap     => v.copy(path = v.path :+ index)
+                    case v: AvroRecord  => v
+                  }
               }
-              .asJava
-            record.put(key, subRecords)
-          case MAP if fieldSchema.getValueType.getType == RECORD =>
-            val subType = fieldSchema.getValueType
-            val subRecords = value.asInstanceOf[util.Map[String, AvroRecord]].asScala.map { case (key, item) =>
-              key -> item.toGenericRecord(subType)
             }
-            record.put(key, subRecords)
-          case RECORD =>
-            val subRecord = value.asInstanceOf[AvroRecord].toGenericRecord(fieldSchema)
-            record.put(key, subRecord)
-          case FIXED =>
-            record.put(key, new GenericData.Fixed(fieldSchema, value.asInstanceOf[String].getBytes))
-          case _ =>
-            record.put(key, value)
-        }
-      } else {
-        record.put(key, value)
+            .partitionMap(identity) match {
+            case (errors, _) if errors.nonEmpty => Left(errors.flatten)
+            case (_, fields)                    => Right(AvroArray(arrayBasePath, fieldName, fields.toList))
+          }
+        case _ => Left(Seq(PluginErrorMessage(s"Expected list value for field '${fieldName.value}' but got '${inValue.kind}'")))
       }
     }
-    record
   }
 
-  def toByteString(schema: Schema): Either[PluginErrorException, ByteString] = {
-    val datumWriter = new GenericDatumWriter[GenericRecord](schema)
-    Using(new ByteArrayOutputStream()) { os =>
-      val encoder = EncoderFactory.get.binaryEncoder(os, null)
-      val record = this.toGenericRecord(schema)
-      datumWriter.write(record, encoder)
-      encoder.flush()
-      os.toByteArray
-    } match {
-      case Success(bytes)     => Right(ByteString.copyFrom(bytes))
-      case Failure(exception) => Left(PluginErrorException(exception))
+  case class AvroMap(
+    override val path: PactFieldPath,
+    override val name: AvroFieldName,
+    value: Map[PactFieldPath, AvroValue] = Map.empty,
+    rules: Seq[MatchingRule] = Seq.empty
+  ) extends AvroValue {
+    override type AvroValueType = Map[PactFieldPath, AvroValue]
+
+    protected[Avro] def toRecordValue: util.Map[String, Any] = value.map { case (_, v) =>
+      v match {
+        case a: AvroArray  => a.name.value -> a.toRecordValue
+        case m: AvroMap    => m.name.value -> m.toRecordValue
+        case r: AvroRecord => r.name.value -> r
+        case av            => av.name.value -> av.value
+      }
+    }.asJava
+
+    protected[Avro] override def addRules(matchingRules: MatchingRuleCategory): Unit =
+      value.foreach { case (_, field) =>
+        field.addRules(matchingRules)
+      }
+  }
+
+  object AvroMap {
+    def apply(rootPath: PactFieldPath, schemaField: Schema.Field, inValue: Value): Either[Seq[PluginError[_]], AvroMap] = {
+      val fieldName = AvroFieldName(schemaField.name())
+      inValue.kind match {
+        case Empty        => Right(AvroMap(rootPath, fieldName))
+        case NullValue(_) => Right(AvroMap(rootPath, fieldName))
+        case StructValue(structValue) =>
+          structValue.fields
+            .map { case (key, singleValue) =>
+              val either = AvroValue(rootPath, key.toFieldName, schemaField.schema(), singleValue)
+              either.map { v =>
+                key.toPactPath -> v
+              }
+            }
+            .partitionMap(identity) match {
+            case (errors, _) if errors.nonEmpty => Left(errors.toSeq.flatten)
+            case (_, fields)                    => Right(AvroMap(rootPath, fieldName, fields.toMap))
+          }
+        case _ => Left(Seq(PluginErrorMessage(s"Expected map value for field '${fieldName.value}' but got '${inValue.kind}'")))
+      }
     }
   }
-}
 
-object AvroRecord {
+  case class AvroRecord(
+    override val path: PactFieldPath,
+    override val name: AvroFieldName,
+    override val value: Map[PactFieldPath, AvroValue],
+    rules: Seq[MatchingRule] = Seq.empty
+  ) extends AvroValue {
+    override type AvroValueType = Map[PactFieldPath, AvroValue]
 
-  def apply(rootPath: PactFieldPath, fieldName: AvroFieldName, fields: Seq[AvroValue]): AvroRecord =
-    AvroRecord(rootPath, fieldName, fields.map(field => field.path -> field).toMap)
+    protected[Avro] override def addRules(matchingRules: MatchingRuleCategory): Unit =
+      value.foreach { case (_, avroValue) =>
+        avroValue.addRules(matchingRules)
+      }
 
-  def apply(schema: Schema, configFields: Map[String, Value]): Either[Seq[PluginError[_]], AvroRecord] =
-    this("$".toPactPath, ".".toFieldName, schema, configFields)
+    def matchingRules: MatchingRuleCategory = {
+      val matchingRules: MatchingRuleCategory = new MatchingRuleCategory(MatchingRuleCategoryName)
+      addRules(matchingRules)
+      matchingRules
+    }
 
-  def apply(rootPath: PactFieldPath, fieldName: AvroFieldName, schema: Schema, configFields: Map[String, Value]): Either[Seq[PluginError[_]], AvroRecord] = {
-    schema.getFields.asScala.toSeq
-      .map { schemaField =>
-        val fieldName = AvroFieldName(schemaField.name())
-        configFields.get(schemaField.name()) match {
-          case Some(configValue) =>
-            schemaField.schema().getType match {
-              case STRING  => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
-              case INT     => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
-              case LONG    => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
-              case FLOAT   => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
-              case DOUBLE  => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
-              case BOOLEAN => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
-              case ENUM    => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
-              case FIXED   => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
-              case BYTES   => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
-              case NULL    => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
-              case RECORD  => AvroRecord(rootPath :+ schemaField.name(), fieldName, schemaField.schema(), configValue.getStructValue.fields)
-              case ARRAY   => AvroArray(rootPath, schemaField, configValue)
-              case MAP     => AvroMap(rootPath :+ schemaField.name(), schemaField, configValue)
-              case UNION   => Left(Seq(PluginErrorException(new UnsupportedOperationException("'UNION' not support as AvroValue"))))
-              case t       => Left(Seq(PluginErrorException(new UnsupportedOperationException(s"Unknown type '$t' not support as AvroValue"))))
-            }
-          case None =>
-            if (schemaField.hasDefaultValue) {
-              AvroValue(rootPath :+ fieldName, fieldName, schemaField.schema().getType, schemaField.defaultVal(), Seq.empty).left.map(e => Seq(e))
-            } else if (schemaField.schema().getType == UNION && schemaField.schema().getTypes.asScala.exists(_.getType == NULL)) {
-              Right(AvroNull(rootPath :+ fieldName, fieldName))
-            } else {
-              Left(Seq(PluginErrorException(new Exception(s"Couldn't find configuration for field: ${schemaField.name()}"))))
-            }
+    private def toRecordValue: util.Map[String, Any] = value.map { case (_, v) =>
+      v match {
+        case a: AvroArray  => a.name.value -> a.toRecordValue
+        case m: AvroMap    => m.name.value -> m.toRecordValue
+        case r: AvroRecord => r.name.value -> r
+        case n: AvroNull   => n.name.value -> null
+        case av            => av.name.value -> av.value
+      }
+    }.asJava
+
+    def toGenericRecord(schema: Schema): GenericRecord = {
+      val record: GenericRecord = new GenericData.Record(schema)
+      toRecordValue.asScala.foreach { case (key, value) =>
+        if (null != value) {
+          val field = schema.getField(key)
+          val fieldSchema = field.schema()
+          fieldSchema.getType match {
+            case ENUM =>
+              record.put(key, new GenericData.EnumSymbol(fieldSchema, value))
+            case ARRAY if fieldSchema.getElementType.getType == RECORD =>
+              val subType = fieldSchema.getElementType
+              val subRecords = value
+                .asInstanceOf[java.util.List[AvroRecord]]
+                .asScala
+                .map { item =>
+                  item.toGenericRecord(subType)
+                }
+                .asJava
+              record.put(key, subRecords)
+            case MAP if fieldSchema.getValueType.getType == RECORD =>
+              val subType = fieldSchema.getValueType
+              val subRecords = value.asInstanceOf[util.Map[String, AvroRecord]].asScala.map { case (key, item) =>
+                key -> item.toGenericRecord(subType)
+              }
+              record.put(key, subRecords)
+            case RECORD =>
+              val subRecord = value.asInstanceOf[AvroRecord].toGenericRecord(fieldSchema)
+              record.put(key, subRecord)
+            case FIXED =>
+              record.put(key, new GenericData.Fixed(fieldSchema, value.asInstanceOf[String].getBytes))
+            case _ =>
+              record.put(key, value)
+          }
+        } else {
+          record.put(key, value)
         }
       }
-      .partitionMap(identity) match {
-      case (errors, _) if errors.nonEmpty => Left(errors.flatten)
-      case (_, value)                     => Right(this(rootPath, fieldName, value))
+      record
+    }
+
+    def toByteString(schema: Schema): Either[PluginErrorException, ByteString] = {
+      val datumWriter = new GenericDatumWriter[GenericRecord](schema)
+      Using(new ByteArrayOutputStream()) { os =>
+        val encoder = EncoderFactory.get.binaryEncoder(os, null)
+        val record = this.toGenericRecord(schema)
+        datumWriter.write(record, encoder)
+        encoder.flush()
+        os.toByteArray
+      } match {
+        case Success(bytes)     => Right(ByteString.copyFrom(bytes))
+        case Failure(exception) => Left(PluginErrorException(exception))
+      }
     }
   }
 
+  object AvroRecord {
+
+    def apply(rootPath: PactFieldPath, fieldName: AvroFieldName, fields: Seq[AvroValue]): AvroRecord =
+      AvroRecord(rootPath, fieldName, fields.map(field => field.path -> field).toMap)
+
+    def apply(schema: Schema, configFields: Map[String, Value]): Either[Seq[PluginError[_]], AvroRecord] =
+      this("$".toPactPath, ".".toFieldName, schema, configFields)
+
+    def apply(rootPath: PactFieldPath, fieldName: AvroFieldName, schema: Schema, configFields: Map[String, Value]): Either[Seq[PluginError[_]], AvroRecord] = {
+      schema.getFields.asScala.toSeq
+        .map { schemaField =>
+          val fieldName = AvroFieldName(schemaField.name())
+          configFields.get(schemaField.name()) match {
+            case Some(configValue) =>
+              schemaField.schema().getType match {
+                case STRING  => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
+                case INT     => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
+                case LONG    => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
+                case FLOAT   => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
+                case DOUBLE  => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
+                case BOOLEAN => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
+                case ENUM    => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
+                case FIXED   => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
+                case BYTES   => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
+                case NULL    => AvroValue(rootPath, fieldName, schemaField.schema(), configValue)
+                case RECORD  => AvroRecord(rootPath :+ schemaField.name(), fieldName, schemaField.schema(), configValue.getStructValue.fields)
+                case ARRAY   => AvroArray(rootPath, schemaField, configValue)
+                case MAP     => AvroMap(rootPath :+ schemaField.name(), schemaField, configValue)
+                case UNION   => Left(Seq(PluginErrorException(new UnsupportedOperationException("'UNION' not support as AvroValue"))))
+                case t       => Left(Seq(PluginErrorException(new UnsupportedOperationException(s"Unknown type '$t' not support as AvroValue"))))
+              }
+            case None =>
+              if (schemaField.hasDefaultValue) {
+                AvroValue(rootPath :+ fieldName, fieldName, schemaField.schema().getType, schemaField.defaultVal(), Seq.empty).left.map(e => Seq(e))
+              } else if (schemaField.schema().getType == UNION && schemaField.schema().getTypes.asScala.exists(_.getType == NULL)) {
+                Right(AvroNull(rootPath :+ fieldName, fieldName))
+              } else {
+                Left(Seq(PluginErrorException(new Exception(s"Couldn't find configuration for field: ${schemaField.name()}"))))
+              }
+          }
+        }
+        .partitionMap(identity) match {
+        case (errors, _) if errors.nonEmpty => Left(errors.flatten)
+        case (_, value)                     => Right(this(rootPath, fieldName, value))
+      }
+    }
+
+  }
 }

--- a/modules/core/src/main/scala/com/collibra/plugin/avro/interaction/InteractionBuilder.scala
+++ b/modules/core/src/main/scala/com/collibra/plugin/avro/interaction/InteractionBuilder.scala
@@ -1,10 +1,11 @@
 package com.collibra.plugin.avro.interaction
 
 import au.com.dius.pact.core.model.matchingrules.{MatchingRule => _, MatchingRules => _, _}
+import com.collibra.plugin.avro.Avro.AvroRecord
 import com.collibra.plugin.avro.AvroPluginConstants._
+import com.collibra.plugin.avro.AvroSchemaBase16Hash
 import com.collibra.plugin.avro.utils.Util._
 import com.collibra.plugin.avro.utils._
-import com.collibra.plugin.avro.{AvroRecord, AvroSchemaBase16Hash}
 import com.google.protobuf.ByteString
 import com.google.protobuf.struct.{Struct, Value}
 import com.typesafe.scalalogging.StrictLogging

--- a/modules/core/src/test/scala/com/collibra/plugin/avro/AvroRecordTest.scala
+++ b/modules/core/src/test/scala/com/collibra/plugin/avro/AvroRecordTest.scala
@@ -2,6 +2,7 @@ package com.collibra.plugin.avro
 
 import au.com.dius.pact.core.model.matchingrules.NumberTypeMatcher.NumberType
 import au.com.dius.pact.core.model.matchingrules._
+import com.collibra.plugin.avro.Avro.AvroRecord
 import com.collibra.plugin.avro.TestSchemas._
 import com.collibra.plugin.avro.utils.MatchingRuleCategoryImplicits._
 import com.google.protobuf.struct.Value.Kind._

--- a/modules/core/src/test/scala/com/collibra/plugin/avro/PactPluginServiceTest.scala
+++ b/modules/core/src/test/scala/com/collibra/plugin/avro/PactPluginServiceTest.scala
@@ -1,5 +1,6 @@
 package com.collibra.plugin.avro
 
+import com.collibra.plugin.avro.Avro._
 import com.collibra.plugin.avro.utils.AvroUtils
 import com.collibra.plugin.avro.utils.StringUtils._
 import com.google.protobuf.struct.Value.Kind._

--- a/modules/core/src/test/scala/com/collibra/plugin/avro/implicits/RecordImplicitsArraysTest.scala
+++ b/modules/core/src/test/scala/com/collibra/plugin/avro/implicits/RecordImplicitsArraysTest.scala
@@ -2,8 +2,7 @@ package com.collibra.plugin.avro.implicits
 
 import au.com.dius.pact.core.matchers.MatchingContext
 import au.com.dius.pact.core.model.matchingrules.MatchingRuleCategory
-import com.collibra.plugin.avro.AvroPluginConstants.MatchingRuleCategoryName
-import com.collibra.plugin.avro.AvroRecord
+import com.collibra.plugin.avro.Avro.AvroRecord
 import com.collibra.plugin.avro.TestSchemas._
 import com.collibra.plugin.avro.implicits.RecordImplicits._
 import com.collibra.plugin.avro.matchers.{BodyItemMatchResult, BodyMismatch}
@@ -15,7 +14,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.jdk.CollectionConverters._
-class RecordImplicitsCollectionsTest extends AnyWordSpec with Matchers with EitherValues {
+class RecordImplicitsArraysTest extends AnyWordSpec with Matchers with EitherValues {
   "GenericRecord" when {
     "comparing Array fields with String values" should {
       val schema = schemaWithField("""{"name": "names", "type": {"type": "array", "items": "string"}}""")
@@ -34,8 +33,7 @@ class RecordImplicitsCollectionsTest extends AnyWordSpec with Matchers with Eith
       val avroRecord = AvroRecord(schema, pactConfiguration).value
       val record = avroRecord.toGenericRecord(schema)
 
-      val matchingRules: MatchingRuleCategory = new MatchingRuleCategory(MatchingRuleCategoryName)
-      avroRecord.addRules(matchingRules)
+      val matchingRules: MatchingRuleCategory = avroRecord.matchingRules
       implicit val context: MatchingContext = new MatchingContext(matchingRules, false)
 
       val expected = List("name-1", "name-2").asJava

--- a/modules/core/src/test/scala/com/collibra/plugin/avro/implicits/RecordImplicitsMapsTest.scala
+++ b/modules/core/src/test/scala/com/collibra/plugin/avro/implicits/RecordImplicitsMapsTest.scala
@@ -1,0 +1,245 @@
+package com.collibra.plugin.avro.implicits
+
+import au.com.dius.pact.core.matchers.MatchingContext
+import au.com.dius.pact.core.model.matchingrules.MatchingRuleCategory
+import com.collibra.plugin.avro.Avro.AvroRecord
+import com.collibra.plugin.avro.TestSchemas._
+import com.collibra.plugin.avro.implicits.RecordImplicits._
+import com.collibra.plugin.avro.matchers.{BodyItemMatchResult, BodyMismatch}
+import com.google.protobuf.struct.Value.Kind._
+import com.google.protobuf.struct.{ListValue => StructListValue, Struct, Value}
+import org.apache.avro.generic.GenericData
+import org.scalatest.EitherValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.jdk.CollectionConverters._
+
+class RecordImplicitsMapsTest extends AnyWordSpec with Matchers with EitherValues {
+  "GenericRecord" when {
+    "comparing Array fields with String values" should {
+      val schema = schemaWithField("""{"name": "names", "type": {"type": "array", "items": "string"}}""")
+      val pactConfiguration: Map[String, Value] = Map(
+        "names" -> Value(
+          ListValue(
+            StructListValue(
+              Seq(
+                Value(StringValue("matching(equalTo, 'name-1')")),
+                Value(StringValue("matching(equalTo, 'name-2')"))
+              )
+            )
+          )
+        )
+      )
+      val avroRecord = AvroRecord(schema, pactConfiguration).value
+      val record = avroRecord.toGenericRecord(schema)
+
+      val matchingRules: MatchingRuleCategory = avroRecord.matchingRules
+      implicit val context: MatchingContext = new MatchingContext(matchingRules, false)
+
+      val expected = List("name-1", "name-2").asJava
+
+      "return empty BodyMatch list for equal fields" in {
+        val otherRecord = new GenericData.Record(schema)
+        otherRecord.put("names", expected)
+
+        val result = record.compare(List("$"), otherRecord).value
+        result should have size 2
+        result shouldBe List(
+          BodyItemMatchResult("$.names.0", List()),
+          BodyItemMatchResult("$.names.1", List())
+        )
+      }
+
+      "return a BodyMatch for unequal fields" in {
+        val otherRecord = new GenericData.Record(schema)
+        val other = List("name-3", "name-4").asJava
+        otherRecord.put("names", other)
+
+        val result = record.compare(List("$"), otherRecord).value
+        result should have size 2
+        result shouldBe
+          List(
+            BodyItemMatchResult(
+              "$.names.0",
+              List(
+                BodyMismatch("name-1", "name-3", "Expected 'name-3' (String) to equal 'name-1' (String)", "$.names.0", "")
+              )
+            ),
+            BodyItemMatchResult(
+              "$.names.1",
+              List(
+                BodyMismatch("name-2", "name-4", "Expected 'name-4' (String) to equal 'name-2' (String)", "$.names.1", "")
+              )
+            )
+          )
+      }
+
+      "return a BodyMatch for missing field value" in {
+        val otherRecord = new GenericData.Record(schema)
+        val result = record.compare(List("$"), otherRecord).value
+        result should have size 1
+        result shouldBe List(
+          BodyItemMatchResult(
+            "$.names",
+            List(
+              BodyMismatch(expected, null, s"Expected null (Null) to equal '$expected' (Array)", "$.names", null)
+            )
+          )
+        )
+      }
+    }
+
+    "comparing Array fields with Integer values" should {
+      val schema = schemaWithField("""{"name": "ids", "type": {"type": "array", "items": "int"}}""")
+      val pactConfiguration: Map[String, Value] = Map(
+        "ids" -> Value(
+          ListValue(
+            StructListValue(
+              Seq(
+                Value(StringValue("matching(equalTo, 1)")),
+                Value(StringValue("matching(equalTo, 2)"))
+              )
+            )
+          )
+        )
+      )
+      val avroRecord = AvroRecord(schema, pactConfiguration).value
+      val record = avroRecord.toGenericRecord(schema)
+
+      val matchingRules: MatchingRuleCategory = avroRecord.matchingRules
+      implicit val context: MatchingContext = new MatchingContext(matchingRules, false)
+
+      val expected = List(1, 2).asJava
+
+      "return empty BodyMatch list for equal fields" in {
+        val otherRecord = new GenericData.Record(schema)
+        otherRecord.put("ids", expected)
+
+        val result = record.compare(List("$"), otherRecord).value
+        result should have size 2
+        result shouldBe List(
+          BodyItemMatchResult("$.ids.0", List()),
+          BodyItemMatchResult("$.ids.1", List())
+        )
+      }
+
+      "return a BodyMatch for unequal fields" in {
+        val otherRecord = new GenericData.Record(schema)
+        val other = List(3, 4).asJava
+        otherRecord.put("ids", other)
+
+        val result = record.compare(List("$"), otherRecord).value
+        result should have size 2
+        result shouldBe
+          List(
+            BodyItemMatchResult(
+              "$.ids.0",
+              List(
+                BodyMismatch(1, 3, "Expected 3 (Integer) to equal 1 (Integer)", "$.ids.0", "")
+              )
+            ),
+            BodyItemMatchResult(
+              "$.ids.1",
+              List(
+                BodyMismatch(2, 4, "Expected 4 (Integer) to equal 2 (Integer)", "$.ids.1", "")
+              )
+            )
+          )
+      }
+
+      "return a BodyMatch for missing field value" in {
+        val otherRecord = new GenericData.Record(schema)
+        val result = record.compare(List("$"), otherRecord).value
+        result should have size 1
+        result shouldBe List(
+          BodyItemMatchResult(
+            "$.ids",
+            List(
+              BodyMismatch(expected, null, s"Expected null (Null) to equal '$expected' (Array)", "$.ids", null)
+            )
+          )
+        )
+      }
+    }
+
+    "comparing Array fields with Record values" should {
+      val schema = schemaWithField("""{
+                                     |  "name": "addresses",
+                                     |  "type": {
+                                     |    "type": "array",
+                                     |    "items": {
+                                     |      "name": "address",
+                                     |      "type": "record",
+                                     |      "fields": [
+                                     |        { "name": "street", "type": "string" }
+                                     |      ]
+                                     |    }
+                                     |  }
+                                     |}""".stripMargin)
+      val pactConfiguration: Map[String, Value] = Map(
+        "addresses" -> Value(
+          ListValue(
+            StructListValue(
+              Seq(
+                Value(StructValue(Struct(Map("street" -> Value(StringValue("matching(equalTo, 'street name')"))))))
+              )
+            )
+          )
+        )
+      )
+      val avroRecord = AvroRecord(schema, pactConfiguration).value
+      val record = avroRecord.toGenericRecord(schema)
+
+      val matchingRules: MatchingRuleCategory = avroRecord.matchingRules
+      implicit val context: MatchingContext = new MatchingContext(matchingRules, false)
+
+      val addressRecord = new GenericData.Record(schema.getField("addresses").schema().getElementType)
+      addressRecord.put("street", "street name")
+      val expected = List(addressRecord).asJava
+
+      "return empty BodyMatch list for equal fields" in {
+        val otherRecord = new GenericData.Record(schema)
+        otherRecord.put("addresses", expected)
+
+        val result = record.compare(List("$"), otherRecord).value
+        result should have size 1
+        result shouldBe List(BodyItemMatchResult("$.addresses.0.street", List()))
+      }
+
+      "return a BodyMatch for unequal fields" in {
+        val otherAddressRecord = new GenericData.Record(schema.getField("addresses").schema().getElementType)
+        otherAddressRecord.put("street", "other")
+        val other = List(otherAddressRecord).asJava
+        val otherRecord = new GenericData.Record(schema)
+        otherRecord.put("addresses", other)
+
+        val result = record.compare(List("$"), otherRecord).value
+        result should have size 1
+        result shouldBe
+          List(
+            BodyItemMatchResult(
+              "$.addresses.0.street",
+              List(
+                BodyMismatch("street name", "other", "Expected 'other' (String) to equal 'street name' (String)", "$.addresses.0.street", "")
+              )
+            )
+          )
+      }
+
+      "return a BodyMatch for missing field value" in {
+        val otherRecord = new GenericData.Record(schema)
+        val result = record.compare(List("$"), otherRecord).value
+        result should have size 1
+        result shouldBe List(
+          BodyItemMatchResult(
+            "$.addresses",
+            List(
+              BodyMismatch(expected, null, s"Expected null (Null) to equal '$expected' (Array)", "$.addresses", null)
+            )
+          )
+        )
+      }
+    }
+  }
+}

--- a/modules/core/src/test/scala/com/collibra/plugin/avro/implicits/RecordImplicitsTest.scala
+++ b/modules/core/src/test/scala/com/collibra/plugin/avro/implicits/RecordImplicitsTest.scala
@@ -2,8 +2,7 @@ package com.collibra.plugin.avro.implicits
 
 import au.com.dius.pact.core.matchers.{BodyMismatch, MatchingContext}
 import au.com.dius.pact.core.model.matchingrules.MatchingRuleCategory
-import com.collibra.plugin.avro.AvroPluginConstants.MatchingRuleCategoryName
-import com.collibra.plugin.avro.AvroRecord
+import com.collibra.plugin.avro.Avro.AvroRecord
 import com.collibra.plugin.avro.TestSchemas._
 import com.collibra.plugin.avro.implicits.RecordImplicits._
 import com.collibra.plugin.avro.matchers.BodyItemMatchResult
@@ -23,8 +22,7 @@ class RecordImplicitsTest extends AnyWordSpec with Matchers with EitherValues {
       val avroRecord = AvroRecord(schema, pactConfiguration).value
       val record = avroRecord.toGenericRecord(schema)
 
-      val matchingRules: MatchingRuleCategory = new MatchingRuleCategory(MatchingRuleCategoryName)
-      avroRecord.addRules(matchingRules)
+      val matchingRules: MatchingRuleCategory = avroRecord.matchingRules
       implicit val context: MatchingContext = new MatchingContext(matchingRules, false)
 
       "return empty BodyMatch list for equal fields" in {
@@ -73,8 +71,7 @@ class RecordImplicitsTest extends AnyWordSpec with Matchers with EitherValues {
       val avroRecord = AvroRecord(schema, pactConfiguration).value
       val record = avroRecord.toGenericRecord(schema)
 
-      val matchingRules: MatchingRuleCategory = new MatchingRuleCategory(MatchingRuleCategoryName)
-      avroRecord.addRules(matchingRules)
+      val matchingRules: MatchingRuleCategory = avroRecord.matchingRules
       implicit val context: MatchingContext = new MatchingContext(matchingRules, false)
 
       "return empty BodyMatch list for equal fields" in {
@@ -123,8 +120,7 @@ class RecordImplicitsTest extends AnyWordSpec with Matchers with EitherValues {
       val avroRecord = AvroRecord(schema, pactConfiguration).value
       val record = avroRecord.toGenericRecord(schema)
 
-      val matchingRules: MatchingRuleCategory = new MatchingRuleCategory(MatchingRuleCategoryName)
-      avroRecord.addRules(matchingRules)
+      val matchingRules: MatchingRuleCategory = avroRecord.matchingRules
       implicit val context: MatchingContext = new MatchingContext(matchingRules, false)
 
       "return empty BodyMatch list for equal fields" in {
@@ -173,8 +169,7 @@ class RecordImplicitsTest extends AnyWordSpec with Matchers with EitherValues {
       val avroRecord = AvroRecord(schema, pactConfiguration).value
       val record = avroRecord.toGenericRecord(schema)
 
-      val matchingRules: MatchingRuleCategory = new MatchingRuleCategory(MatchingRuleCategoryName)
-      avroRecord.addRules(matchingRules)
+      val matchingRules: MatchingRuleCategory = avroRecord.matchingRules
       implicit val context: MatchingContext = new MatchingContext(matchingRules, false)
 
       "return empty BodyMatch list for equal fields" in {
@@ -223,8 +218,7 @@ class RecordImplicitsTest extends AnyWordSpec with Matchers with EitherValues {
       val avroRecord = AvroRecord(schema, pactConfiguration).value
       val record = avroRecord.toGenericRecord(schema)
 
-      val matchingRules: MatchingRuleCategory = new MatchingRuleCategory(MatchingRuleCategoryName)
-      avroRecord.addRules(matchingRules)
+      val matchingRules: MatchingRuleCategory = avroRecord.matchingRules
       implicit val context: MatchingContext = new MatchingContext(matchingRules, false)
 
       "return empty BodyMatch list for equal fields" in {
@@ -273,8 +267,7 @@ class RecordImplicitsTest extends AnyWordSpec with Matchers with EitherValues {
       val avroRecord = AvroRecord(schema, pactConfiguration).value
       val record = avroRecord.toGenericRecord(schema)
 
-      val matchingRules: MatchingRuleCategory = new MatchingRuleCategory(MatchingRuleCategoryName)
-      avroRecord.addRules(matchingRules)
+      val matchingRules: MatchingRuleCategory = avroRecord.matchingRules
       implicit val context: MatchingContext = new MatchingContext(matchingRules, false)
 
       "return empty BodyMatch list for equal fields" in {
@@ -323,8 +316,7 @@ class RecordImplicitsTest extends AnyWordSpec with Matchers with EitherValues {
       val avroRecord = AvroRecord(schema, pactConfiguration).value
       val record = avroRecord.toGenericRecord(schema)
 
-      val matchingRules: MatchingRuleCategory = new MatchingRuleCategory(MatchingRuleCategoryName)
-      avroRecord.addRules(matchingRules)
+      val matchingRules: MatchingRuleCategory = avroRecord.matchingRules
       implicit val context: MatchingContext = new MatchingContext(matchingRules, false)
       val green = new GenericData.EnumSymbol(schema, "GREEN")
 
@@ -375,8 +367,7 @@ class RecordImplicitsTest extends AnyWordSpec with Matchers with EitherValues {
       val avroRecord = AvroRecord(schema, pactConfiguration).value
       val record = avroRecord.toGenericRecord(schema)
 
-      val matchingRules: MatchingRuleCategory = new MatchingRuleCategory(MatchingRuleCategoryName)
-      avroRecord.addRules(matchingRules)
+      val matchingRules: MatchingRuleCategory = avroRecord.matchingRules
       implicit val context: MatchingContext = new MatchingContext(matchingRules, false)
       val fixed = new GenericData.Fixed(schema.getField("md5").schema(), "\\u0000\\u0001\\u0002\\u0003".getBytes)
 
@@ -427,8 +418,7 @@ class RecordImplicitsTest extends AnyWordSpec with Matchers with EitherValues {
       val avroRecord = AvroRecord(schema, pactConfiguration).value
       val record = avroRecord.toGenericRecord(schema)
 
-      val matchingRules: MatchingRuleCategory = new MatchingRuleCategory(MatchingRuleCategoryName)
-      avroRecord.addRules(matchingRules)
+      val matchingRules: MatchingRuleCategory = avroRecord.matchingRules
       implicit val context: MatchingContext = new MatchingContext(matchingRules, false)
 
       "return empty BodyMatch list for equal fields" in {


### PR DESCRIPTION
Hide methods only accessed in AvroValue and it's children
remove parserules for ListValue, as it's not used