### PR TITLE
fix(compareContents): plain type matcher not working

### DIFF
--- a/modules/plugin/src/main/scala/com/github/austek/plugin/avro/compare/CompareContentsResponseBuilder.scala
+++ b/modules/plugin/src/main/scala/com/github/austek/plugin/avro/compare/CompareContentsResponseBuilder.scala
@@ -91,16 +91,13 @@ object CompareContentsResponseBuilder extends StrictLogging {
           key -> new MatchingRuleGroup(
             rules.rule.flatMap { matchingRule =>
               matchingRule.values.map { struct =>
-                val json = PactCoreUtils.structToJson(toJavaProto(struct))
-                if (json.size() > 0 || matchingRule.`type`.isEmpty) {
-                  MatchingRule.fromJson(json)
-                } else {
-                  MatchingRule.fromJson(
-                    Json.toJson(
-                      Map("match" -> matchingRule.`type`).asJava
-                    )
-                  )
-                }
+                                MatchingRule.fromJson(
+                  Option(PactCoreUtils.structToJson(toJavaProto(struct)))
+                    .filterNot(ruleJson => ruleJson.size() == 0 && matchingRule.`type`.nonEmpty) match {
+                    case Some(value) => value
+                    case None => Json.toJson(Map("match" -> matchingRule.`type`).asJava)
+                  }
+                )
               }
             }.asJava
           )

--- a/modules/plugin/src/main/scala/com/github/austek/plugin/avro/compare/CompareContentsResponseBuilder.scala
+++ b/modules/plugin/src/main/scala/com/github/austek/plugin/avro/compare/CompareContentsResponseBuilder.scala
@@ -2,6 +2,7 @@ package com.github.austek.plugin.avro.compare
 
 import au.com.dius.pact.core.matchers.MatchingContext
 import au.com.dius.pact.core.model.matchingrules.{MatchingRule, MatchingRuleCategory, MatchingRuleGroup}
+import au.com.dius.pact.core.support.json.JsonValue
 import com.github.austek.plugin.avro.AvroPluginConstants.MatchingRuleCategoryName
 import com.github.austek.plugin.avro.ContentTypeConstants._
 import com.github.austek.plugin.avro.utils._
@@ -14,6 +15,7 @@ import org.apache.avro.Schema
 import org.apache.avro.Schema.Type.{RECORD, UNION}
 import org.apache.avro.generic.GenericRecord
 
+import java.util
 import scala.jdk.CollectionConverters._
 import scala.util.matching.Regex
 
@@ -90,7 +92,13 @@ object CompareContentsResponseBuilder extends StrictLogging {
           key -> new MatchingRuleGroup(
             rules.rule.flatMap { matchingRule =>
               matchingRule.values.map { struct =>
-                MatchingRule.fromJson(PactCoreUtils.structToJson(toJavaProto(struct)))
+                var json = PactCoreUtils.structToJson(toJavaProto(struct))
+                if (0 == json.size() && matchingRule.`type`.nonEmpty) {
+                  val map = new util.HashMap[String, JsonValue]()
+                  map.put("match", new JsonValue.StringValue(matchingRule.`type`))
+                  json = new JsonValue.Object(map)
+                }
+                MatchingRule.fromJson(json)
               }
             }.asJava
           )

--- a/modules/plugin/src/main/scala/com/github/austek/plugin/avro/compare/CompareContentsResponseBuilder.scala
+++ b/modules/plugin/src/main/scala/com/github/austek/plugin/avro/compare/CompareContentsResponseBuilder.scala
@@ -91,11 +91,11 @@ object CompareContentsResponseBuilder extends StrictLogging {
           key -> new MatchingRuleGroup(
             rules.rule.flatMap { matchingRule =>
               matchingRule.values.map { struct =>
-                                MatchingRule.fromJson(
+                MatchingRule.fromJson(
                   Option(PactCoreUtils.structToJson(toJavaProto(struct)))
                     .filterNot(ruleJson => ruleJson.size() == 0 && matchingRule.`type`.nonEmpty) match {
                     case Some(value) => value
-                    case None => Json.toJson(Map("match" -> matchingRule.`type`).asJava)
+                    case None        => Json.toJson(Map("match" -> matchingRule.`type`).asJava)
                   }
                 )
               }

--- a/modules/plugin/src/main/scala/com/github/austek/plugin/avro/implicits/SchemaFieldImplicits.scala
+++ b/modules/plugin/src/main/scala/com/github/austek/plugin/avro/implicits/SchemaFieldImplicits.scala
@@ -12,6 +12,7 @@ import org.apache.avro.Schema
 import org.apache.avro.Schema.Type._
 import org.apache.avro.generic.GenericData.{EnumSymbol, Fixed}
 import org.apache.avro.generic.GenericRecord
+import org.apache.avro.util.Utf8
 
 import java.util
 import scala.jdk.CollectionConverters._
@@ -273,14 +274,24 @@ object SchemaFieldImplicits extends StrictLogging {
       logger.debug(s">>> compareValue($path, $field, $expected, $actual, $context)")
       if (context.matcherDefined(path.asJava)) {
         logger.debug(s"compareValue: Matcher defined for path $path")
+
+        val expectedJava = expected match {
+          case s: Utf8 => s.toString
+          case _       => expected
+        }
+        val actualJava = actual match {
+          case s: Utf8 => s.toString
+          case _       => actual
+        }
+
         List(
           new AvroBodyItemMatchResult(
             valuePath,
             Matchers.domatch(
               context,
               path.asJava,
-              expected,
-              actual,
+              expectedJava,
+              actualJava,
               (expected: Any, actual: Any, message: String, path: java.util.List[String]) =>
                 BodyMismatch(expected, actual, message, constructPath(path), diffCallback())
             )


### PR DESCRIPTION
When only type is defined and no extra matchers then EqualsMatcher was used. This made it impossible to have just a type matcher.

--------

As I have not written Scala before any comments on code style and standard library usage are very welcome.