### PR TITLE
Address pre-requisites

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,6 +4,11 @@ ____
 Pact plugin for testing messages serialised by https://avro.apache.org/docs[Apache Avro] using the https://docs.pact.io[Pact] contract testing framework.
 ____
 
+== Pre-requisites
+
+This plugin requires the following to be installed:
+
+* Java 17+
 
 == Development Roadmap
 

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -18,7 +18,7 @@ ROOT:: Contains the documentation that is specific to {project-display-name}.
 While IntelliJ will have inline viewing per page, sometimes references do not always get pulled in especially from a separate repo.
 Developers can validate what they have documented is rendered correctly in context by running antora locally to generate the docs:
 
-[source,bash]
+[source,console]
 ----
 npm ci && npx antora antora-playbook.yml --fetch --stacktrace
 ----

--- a/project/PublishSettings.scala
+++ b/project/PublishSettings.scala
@@ -39,7 +39,7 @@ object PublishSettings {
 
   private def generateInstallPluginSh(artifactDir: sbt.File, version: String): sbt.File = {
     val file = artifactDir / "install-plugin.sh"
-    val content = """#!/usr/bin/env bash
+    val content = """#!/bin/sh
       |
       |set -e
       |
@@ -50,8 +50,8 @@ object PublishSettings {
       |   Darwin|Linux|CYGWIN*|MINGW32*|MSYS*|MINGW*)
       |     echo '== Installing plugin =='
       |     mkdir -p ~/.pact/plugins/avro-${VERSION}
-      |     wget https://github.com/austek/pact-avro-plugin/releases/download/v${VERSION}/pact-plugin.json -O ~/.pact/plugins/avro-${VERSION}/pact-plugin.json
-      |     wget -c https://github.com/austek/pact-avro-plugin/releases/download/v${VERSION}/pact-avro-plugin.tgz \
+      |     wget --no-verbose https://github.com/austek/pact-avro-plugin/releases/download/v${VERSION}/pact-plugin.json -O ~/.pact/plugins/avro-${VERSION}/pact-plugin.json
+      |     wget --no-verbose -c https://github.com/austek/pact-avro-plugin/releases/download/v${VERSION}/pact-avro-plugin.tgz \
       |     -O - | tar -xz -C ~/.pact/plugins/avro-${VERSION}
       |     ;;
       |


### PR DESCRIPTION
* `installation-plugin.sh` uses `/bin/sh` instead of bash
* Add pre-requisites to README.adoc

fix #36