### PR TITLE
fix: update docker-compose to docker compose due to deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 
       - name: Start containers
-        run: docker-compose -f docker-compose.yml up -d
+        run: docker compose -f docker-compose.yml up -d
 
       - name: Build project
         run: sbt ++${{ matrix.scala }} compile scalafmtCheckAll javafmtCheckAll plugin/test
@@ -78,7 +78,7 @@ jobs:
 
       - name: Stop containers
         if: always()
-        run: docker-compose -f docker-compose.yml down
+        run: docker compose -f docker-compose.yml down
 
       - name: Compress target directories
         run: tar cf targets.tar target modules/plugin/target modules/examples/provider/target modules/examples/consumer/target project/target

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -67,7 +67,7 @@ sbt consumer/test
 .Run Pact broker
 [source,shell]
 ----
-docker-compose -f docker-compose.yml up -d
+docker compose -f docker-compose.yml up -d
 ----
 
 .Upload Consumer Pact
@@ -85,7 +85,7 @@ sbt provider/test
 .Stop Pact broker
 [source,shell]
 ----
-docker-compose -f docker-compose.yml down
+docker compose -f docker-compose.yml down
 ----
 
 

--- a/github-actions.sbt
+++ b/github-actions.sbt
@@ -2,7 +2,7 @@
 ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Run(
     name = Some("Start containers"),
-    commands = List("docker-compose -f docker-compose.yml up -d")
+    commands = List("docker compose -f docker-compose.yml up -d")
   ),
   WorkflowStep.Sbt(
     name = Some("Build project"),
@@ -23,7 +23,7 @@ ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Run(
     cond = Some("always()"),
     name = Some("Stop containers"),
-    commands = List("docker-compose -f docker-compose.yml down")
+    commands = List("docker compose -f docker-compose.yml down")
   )
 )
 // Add windows-latest when https://github.com/sbt/sbt/issues/7082 is resolved


### PR DESCRIPTION
docker-compose has been deprecated in docker compose v2

https://docs.docker.com/compose/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2

causes the build to fail