### PR TITLE
fix(win): fix plugin startup / use FileAppender

### DIFF
--- a/modules/plugin/src/main/resources/logback.xml
+++ b/modules/plugin/src/main/resources/logback.xml
@@ -6,18 +6,8 @@
         </encoder>
     </appender>
 
-    <appender name="PLAIN_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="PLAIN_FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/plugin.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <!-- daily rollover -->
-            <fileNamePattern>logs/plugin.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
-            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                <!-- or whenever the file size reaches 50MB -->
-                <maxFileSize>50MB</maxFileSize>
-            </timeBasedFileNamingAndTriggeringPolicy>
-            <!-- keep 30 days' worth of history -->
-            <maxHistory>30</maxHistory>
-        </rollingPolicy>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{50}:%line - %message%n%xException{10}</pattern>
         </encoder>


### PR DESCRIPTION
issues on reading the plugin startup message when using system threads over tokio tasks, seem to be due to the RollingFileAppender

Built locally on a mac m1 (via docker) and tested in a windows VM using parallels

Plugin now start ups correctly, and maintains logs. fixes #42 

Using the pact-plugin-driver with this change

https://github.com/pact-foundation/pact-plugins/pull/69/files#diff-e21b8ae9cb59f07bada083f39629f6fbc221a1c6ca0ad395799d0bad5f7bc941R290

in order to terminate child processes on windows, will fix the shut down issues.

Tested e2e with the avro plugin example in https://github.com/pact-foundation/pact-go/tree/master/examples/avro